### PR TITLE
Support to pass keyword arguments to HtmlFormatter of Pygments

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,7 @@ Usage:
 - enclose your code snippet in a pre tag with the non-standard "lang" attribute set to a supported language like this:
   <pre lang="python">....</pre>
 - see the view and demo template for examples on how to use the "pygmentify" and "pygmentify_inline" filters (the later is rather useful for RSS feeds) or the "pygment" tag
+- While using the "pygment" template tag, you can pass keyword arguments that you would pass to Pygments HtmlFormatter class constructor by passing them as with keyword arguments along with the pygment tag. Look at demo template for examples. There is one caveat with this feature still. You can only pass Python values as argument values (like Strings wrapped within quotes or True or False boolean values, etc.). It doesn't support Django template/context variables as arguments yet.
 
 Notes:
 - the custom HTML formatter class displays each line as an ordered list element, thus implementing line numbering without interfering with copy/pasting

--- a/django_pygments/templates/django_pygments/demo.html
+++ b/django_pygments/templates/django_pygments/demo.html
@@ -21,7 +21,9 @@
             {{ snippet|pygmentify_inline }}
             <br />
             <h3>the "pygment" tag</h3>
-            {% pygment %}
+            <!-- lineseparator="<br/><br/>" will be passed as keyword
+                 argument to the HtmlFormatter class -->
+            {% pygment lineseparator="<br/><br/>" %}
                             <pre lang="bash">
 stefan$ ./manage.py runserver_cp
 Validating models...

--- a/django_pygments/templatetags/pygmentify.py
+++ b/django_pygments/templatetags/pygmentify.py
@@ -28,8 +28,10 @@ def pygmentify_inline(value):
     return mark_safe(res)
 
 class PygmentifyNode(template.Node):
-    def __init__(self, nodelist):
+    def __init__(self, nodelist, **kwargs):
         self.nodelist = nodelist
+        self.kwargs = kwargs
+
     def render(self, context):
         output = self.nodelist.render(context)
         try:
@@ -53,5 +55,4 @@ def pygment(parser, token):
 
     nodelist = parser.parse(('endpygment',))
     parser.delete_first_token()
-    return PygmentifyNode(nodelist)
-
+    return PygmentifyNode(nodelist, **kwargs)

--- a/django_pygments/templatetags/pygmentify.py
+++ b/django_pygments/templatetags/pygmentify.py
@@ -42,6 +42,15 @@ class PygmentifyNode(template.Node):
 
 @register.tag
 def pygment(parser, token):
+    token_args = token.split_contents()
+    kwargs = {}
+    for item in token_args[1:]:
+        kw_parts = [i.strip() for i in item.split('=')]
+        # we intentionally leave kw_parts[1] as is without any
+        # exception handling so that if the argument supplied is
+        # not of the keyword argume type, the error is propogated
+        kwargs[kw_parts[0]] = eval(kw_parts[1])
+
     nodelist = parser.parse(('endpygment',))
     parser.delete_first_token()
     return PygmentifyNode(nodelist)

--- a/django_pygments/templatetags/pygmentify.py
+++ b/django_pygments/templatetags/pygmentify.py
@@ -38,7 +38,7 @@ class PygmentifyNode(template.Node):
             res = pygmentify_html(output, **self.kwargs)
         except Exception, e:
             print e
-            print u'value="%s"' % value
+            print u'value="%s"' % output
             res = output
         return mark_safe(res)
 

--- a/django_pygments/templatetags/pygmentify.py
+++ b/django_pygments/templatetags/pygmentify.py
@@ -35,7 +35,7 @@ class PygmentifyNode(template.Node):
     def render(self, context):
         output = self.nodelist.render(context)
         try:
-            res = pygmentify_html(output)
+            res = pygmentify_html(output, **self.kwargs)
         except Exception, e:
             print e
             print u'value="%s"' % value


### PR DESCRIPTION
Django-pyments is an awesome plugin. It reduced a lot of my work, I would have otherwise had to do to get to this point. A lot of development time saved. Thank you very much for that.

I wanted to use Pygments CSS generated by richleland in his repo at https://github.com/richleland/pygments-css. He uses codehilite as the cssclass for all the styling. So I wanted to pass this cssclass keyword argument to HtmlFormatter of Pygments and I did not find an easy way to do it while using django-pygments. So I created these set of patches and I am currently using it for the project at https://github.com/FOSSEE/pytask. I know that these changes are not mature yet, they won't take the Django template variable/context variable values as arguments for keywords. But at least this works as a proof of concept and I thought I will contribute it back. If you are interested, please let me know, I will work on adding the support for passing Django template context variables as arguments along with these keywords.
